### PR TITLE
203-Add 10 point gain in rule adoption

### DIFF
--- a/_rules/203.md
+++ b/_rules/203.md
@@ -3,4 +3,4 @@ number: 203
 mutability: mutable
 ---
 
-A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority. If a rule-change is adopted, students will receive 10 points.
+A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority. If a rule-change is adopted, proposers will receive 10 points, subject to any handicaps.

--- a/_rules/203.md
+++ b/_rules/203.md
@@ -3,4 +3,4 @@ number: 203
 mutability: mutable
 ---
 
-A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority.
+A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority. If a rule-change is adopted, students will receive 10 points.


### PR DESCRIPTION
Adds in the ability to gain points when a rule is accepted. While this is attempted in rule 202, along with the original nomic rules, it appears to not be entered correctly allowing for no point gain.  Instead of amending rule 202, it is more cohesive to modify rule 203 which determines the criteria for rule acceptance. This makes gaining points automatic after the rule acceptance instead of a determined 'turn' step.