### PR TITLE
206-reduce rule proposal penalty

### DIFF
--- a/_rules/206.md
+++ b/_rules/206.md
@@ -3,5 +3,5 @@ number: 206
 mutability: mutable
 ---
 
-When a proposed rule-change is defeated, the player who proposed it loses 10 points.
+When a proposed rule-change is defeated, the player who proposed it loses 5 points.
 


### PR DESCRIPTION
The current penalty for proposing a rule-change is equal to the much harder task of getting a proposal accepted. To allow for more creativity and participation, we can reduce the penalty from 10 points to 5 points.