### PR TITLE
Create 373.md

### DIFF
--- a/_rules/373.md
+++ b/_rules/373.md
@@ -3,6 +3,9 @@ number: 373
 mutability: mutable
 ---
 
-If a player loses enough points during the game of Nomic to end up with a negative point balance at the end of class, that point balance will be multiplied by -1, giving the player a positive point balance instead of a negative point balance. For example, if a player is left with -40 points at the end of the class meeting, that point balance is converted to 40 points.
+For the purposes of this rule, gameplay points are considered separately from penalties for lateness or absence or other reasons.
 
-If the rule passes, all players, except for the player proposing this rule, receives 15 points. 
+If a player loses enough gameplay points during the game of Nomic to end up with a negative gameplay point balance at the end of class, that gameplay point balance will be multiplied by -1, giving the player a positive gameplay point balance instead of a negative gameplay point balance. For example, if a player is left with -40 gameplay points at the end of the class meeting, that gameplay point balance is converted to 40 gameplay points.
+
+If the rule passes, all players, except for the player proposing this rule, receives 15 gameplay points.
+All points on the scoreboard when this rule passes are considered gameplay points.

--- a/_rules/373.md
+++ b/_rules/373.md
@@ -1,0 +1,8 @@
+---
+number: 373
+mutability: mutable
+---
+
+If a player loses enough points during the game of Nomic to end up with a negative point balance at the end of class, that point balance will be multiplied by -1, giving the player a positive point balance instead of a negative point balance. For example, if a player is left with -40 points at the end of the class meeting, that point balance is converted to 40 points.
+
+If the rule passes, all players, except for the player proposing this rule, receives 15 points. 


### PR DESCRIPTION
This rule is intended to keep players with low or negative scores engaged in the game,  and allows for creative actions, if the player's score is close to zero.