### PR TITLE
Create 214

### DIFF
--- a/_rules/214.md
+++ b/_rules/214.md
@@ -3,4 +3,4 @@ number: 214
 mutability: mutable
 ---
 
-The players must decide on the minimum number of eligible players that are required to be present at a meeting for voting to take place. If fewer than this minimum number of eligible players are present at a meeting, no voting on rules shall take place until the minimum number is reached. A new rule listing this chosen minimum number should be created and voted on by at least 2/3 of all eligible players present at the voting.
+The players must decide on the minimum number of eligible players that are required to be present at a meeting for voting to take place. If fewer than this minimum number of eligible players are present at a meeting, no voting on rules shall take place until the minimum number is reached. A new rule listing this chosen minimum number should be created and voted on by at least 2/3 of all eligible players.

--- a/_rules/214.md
+++ b/_rules/214.md
@@ -1,5 +1,5 @@
 ---
-number: 390
+number: 214
 mutability: mutable
 ---
 

--- a/_rules/390.md
+++ b/_rules/390.md
@@ -1,0 +1,6 @@
+---
+number: 390
+mutability: mutable
+---
+
+The players must decide on the minimum number of eligible players that are required to be present at a meeting for voting to take place. If fewer than this minimum number of eligible players are present at a meeting, no voting on rules shall take place until the minimum number is reached. A new rule listing this chosen minimum number should be created and voted on by at least 2/3 of all eligible players present at the voting.


### PR DESCRIPTION
Rationale: given that the number of players is very small (currently 9 players,) a scenario in which a very small number of players arrive at a meeting is plausible. Example: 2 players (aside from the Professor) arrive at a meeting on a harsh weather day. Voting shouldn't take place in such a case. Even though the players may choose the majority (5) to be the minimum number, this number must still be added to the set of rules.