### PR TITLE
Create 405

### DIFF
--- a/_rules/405.md
+++ b/_rules/405.md
@@ -3,4 +3,4 @@ number: 405
 mutability: mutable
 ---
 
-If a vote passes with an amendment, the player who introduced the amendment retains half the points, rounded up to the nearest iteger, of the player who introduced the new rule.
+If a rule change passes with an amendment, each player who introduced an adopted amendment to the rule change will be awarded points equal to half of the points awarded to the player who proposed the rule change, rounded up to the nearest integer.


### PR DESCRIPTION
If a vote passes with an amendment, the player who introduced the amendment retains half the points, rounded to the nearest integer, of the player who introduced the new rule.