### PR TITLE
Create 423.md

### DIFF
--- a/_rules/421.md
+++ b/_rules/421.md
@@ -1,0 +1,9 @@
+---
+number: 421
+mutability: mutable
+---
+
+Before any proposed rule change can be voted on, it has to have been formally reviewed on GitHub by one other player, who must post their approval in the pull request as a comment.
+The reviewer will gain half of any point gains of the proposing player and lose half of any point loss of the proposing player for point gains and point losses that result from adoption or rejection of the proposed rule change.
+
+This rule will start to apply after the day in which it is adopted.

--- a/_rules/423.md
+++ b/_rules/423.md
@@ -1,5 +1,5 @@
 ---
-number: 421
+number: 423
 mutability: mutable
 ---
 


### PR DESCRIPTION
As a way to give us a reason to familiarize ourselves with code review practices, and as a way to cut down on the amount of amending proposals we do in the game I propose that each rule change proposal must have been discussed in an ad-hoc committee of two: the proposer and one reviewer, before going in front of the entire player assembly.

To incentivize reviewers, they share a fraction of any point gain or loss of the proposer.